### PR TITLE
Fix Fedora build

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,6 +6,6 @@ from bincrafters import build_template_default
 
 if __name__ == "__main__":
 
-    builder = build_template_default.get_builder()
+    builder = build_template_default.get_builder(pure_c=True)
 
     builder.run()


### PR DESCRIPTION
fixes https://github.com/bincrafters/community/issues/904

When running Feroda, pc-files are really required, but our OpenSSL package is camel-cased, which means we need to rename it to lower-case, otherwise, opusfile won't find it.